### PR TITLE
Ignore new aliases

### DIFF
--- a/lib/emojibot/bot.ex
+++ b/lib/emojibot/bot.ex
@@ -10,6 +10,8 @@ defmodule Emojibot.Bot do
               thread_ts: nil
   end
 
+  def handle_event(%{value: "alias:" <> _, type: "emoji_changed", subtype: "add"}, _, state), do: {:ok, state}
+
   def handle_event(%{name: name, type: "emoji_changed", subtype: "add"}, slack, state) do
     emoji_channel_id =
       :emojibot


### PR DESCRIPTION
We don’t want to post new emoji aliases to the channel.